### PR TITLE
bannersnack.com add third-party only

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -385,7 +385,7 @@ emag.ro##.ns-wrap-bottom-right
 ||ads.tradeads.eu^
 ||adservingfactory.com^
 ||amazonaws.com/newd.cetrk.com/
-||bannersnack.com^
+||bannersnack.com^$third-party
 ||brat-online.ro^
 ||chargeplatform.com^
 ||evensys.ro^$third-party


### PR DESCRIPTION
Update rule for bannersnack.com to allow the website to work properly.

The main app of the website, the blog and the app are broken by the rule. The url of the broken services are as follows:
https://www.bannersnack.com
https://app.bannersnack.com
https://blog.bannersnack.com